### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/scripts/add_graphics_poseidon.py
+++ b/scripts/add_graphics_poseidon.py
@@ -48,7 +48,7 @@ def main():
     list_len = len(args.input_files)
 
     for i, ifile in enumerate(args.input_files):
-        print "Processing file %i/%i: %s" % (i+1, list_len, os.path.basename(ifile))
+        print "Processing file {0:d}/{1:d}: {2!s}".format(i+1, list_len, os.path.basename(ifile))
 
         scene = io.load_geotiff(ifile)
         scene.compose_rgb_image([1, 2, 3])

--- a/scripts/amsr2_mosaic.py
+++ b/scripts/amsr2_mosaic.py
@@ -22,7 +22,7 @@ def main():
     scene_list = []
 
     for input_file in args.input_files:
-        print "Loading %s" % (input_file)
+        print "Loading {0!s}".format((input_file))
         amsr2_scene = io.load_osisaf_amsr2_netcdf(input_file, bands=args.channels)
         scene_list.append(amsr2_scene)
 

--- a/scripts/mitiff_mosaic.py
+++ b/scripts/mitiff_mosaic.py
@@ -22,7 +22,7 @@ def main():
     scene_list = []
 
     for input_file in args.input_files:
-        print "Loading %s" % (input_file)
+        print "Loading {0!s}".format((input_file))
         mitiff = io.load_mitiff(input_file, bands=args.channels)
         scene_list.append(mitiff)
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:metno:satistjenesten?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:metno:satistjenesten?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)